### PR TITLE
Add caching to workspace listing

### DIFF
--- a/cmd/workspace_list.go
+++ b/cmd/workspace_list.go
@@ -62,11 +62,28 @@ func (w *WorkspaceListCmd) Run(ctx *Context) error {
 		return err
 	}
 
+	settings, err := lib.NewSettings()
+	if err != nil {
+		resp.SetError(err)
+		return err
+	}
+
+	if err := settings.Load(); err != nil {
+		resp.SetError(err)
+		return err
+	}
+
 	lister := &workspaceLister{
 		workspaceClient: client.Workspaces,
 	}
 
-	items, err := lister.FetchWorkspaces()
+	wsCache, err := lib.NewCache("workspaces", settings.CacheTimeout, lister.FetchWorkspaces)
+	if err != nil {
+		resp.SetError(err)
+		return err
+	}
+
+	items, err := wsCache.Get()
 	if err != nil {
 		resp.SetError(err)
 		return err

--- a/cmd/workspace_list.go
+++ b/cmd/workspace_list.go
@@ -24,6 +24,35 @@ func paginate(nextPage int) tfe.WorkspaceListOptions {
 	}
 }
 
+type workspaceClient interface {
+	List(context.Context, string, tfe.WorkspaceListOptions) (*tfe.WorkspaceList, error)
+}
+
+type workspaceLister struct {
+	workspaceClient
+}
+
+func (wl *workspaceLister) FetchWorkspaces() ([]models.ListItem, error) {
+	items := make([]models.ListItem, 0)
+	for nextPage := 1; nextPage != 0; {
+		workspaceList, err := wl.List(context.Background(), "nerdwallet", paginate(nextPage))
+		if err != nil {
+			return nil, err
+		}
+		for _, workspace := range workspaceList.Items {
+			items = append(items, models.ListItem{
+				Title:    workspace.Name,
+				Subtitle: workspace.Description,
+				Arg:      workspace.Name,
+				Valid:    true,
+			})
+		}
+		nextPage = workspaceList.NextPage
+	}
+
+	return items, nil
+}
+
 func (w *WorkspaceListCmd) Run(ctx *Context) error {
 	resp := models.NewScriptResponse()
 
@@ -33,21 +62,18 @@ func (w *WorkspaceListCmd) Run(ctx *Context) error {
 		return err
 	}
 
-	for nextPage := 1; nextPage != 0; {
-		workspaceList, err := client.Workspaces.List(context.Background(), "nerdwallet", paginate(nextPage))
-		if err != nil {
-			resp.SetError(err)
-			return err
-		}
-		for _, workspace := range workspaceList.Items {
-			resp.AddItem(models.ListItem{
-				Title:    workspace.Name,
-				Subtitle: workspace.Description,
-				Arg:      workspace.Name,
-				Valid:    true,
-			})
-		}
-		nextPage = workspaceList.NextPage
+	lister := &workspaceLister{
+		workspaceClient: client.Workspaces,
+	}
+
+	items, err := lister.FetchWorkspaces()
+	if err != nil {
+		resp.SetError(err)
+		return err
+	}
+
+	for _, item := range items {
+		resp.AddItem(item)
 	}
 
 	resp.SendFeedback()

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-tfe v0.18.0
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/zalando/go-keyring v0.1.1

--- a/lib/cache.go
+++ b/lib/cache.go
@@ -1,0 +1,68 @@
+package lib
+
+import (
+	"encoding/json"
+	"os"
+	"os/user"
+	"path"
+
+	"github.com/dishbreak/terraform-cloud-launcher/models"
+)
+
+type ItemCache struct {
+	Items           []models.ListItem `json:"items"`
+	ExpiryTime      int               `json:"expiryTime"`
+	refreshCallback func() ([]models.ListItem, error)
+	filePath        string
+}
+
+func NewCache(name string, timeout int, callback func() []models.ListItem) (*ItemCache, error) {
+	c := &ItemCache{}
+
+	current, err := user.Current()
+	if err != nil {
+		return c, err
+	}
+
+	c.filePath = path.Join(current.HomeDir, SettingsDir, CacheDir, name+".json")
+	return c, nil
+}
+
+func (c *ItemCache) Get() ([]models.ListItem, error) {
+
+}
+
+func (c *ItemCache) save() error {
+	err := os.MkdirAll(path.Base(c.filePath), 0700)
+	if err != nil {
+		return err
+	}
+
+	fp, err := os.Create(c.filePath)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	encoder := json.NewEncoder(fp)
+	return encoder.Encode(c)
+}
+
+func (c *ItemCache) refresh(force bool) error {
+	if fp, err := os.Open(c.filePath); err == nil {
+		defer fp.Close()
+		decoder := json.NewDecoder(fp)
+		err := decoder.Decode(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		items, err := c.refreshCallback()
+		if err != nil {
+			return err
+		}
+		c.Items = items
+		return c.save()
+	}
+	return nil
+}

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -1,6 +1,9 @@
 package lib
 
 const (
-	AppName  string = "Alfred TFE Browser"
-	UserName string = "Alfred"
+	AppName          string = "Alfred TFE Browser"
+	UserName         string = "Alfred"
+	SettingsDir      string = ".tfe-launcher"
+	SettingsFilename string = "settings.json"
+	CacheDir         string = "cache"
 )

--- a/lib/settings.go
+++ b/lib/settings.go
@@ -1,0 +1,59 @@
+package lib
+
+import (
+	"encoding/json"
+	"os"
+	"os/user"
+	"path"
+
+	"github.com/pkg/errors"
+)
+
+type Settings struct {
+	CacheTimeout int
+	filePath     string
+}
+
+func NewSettings() (*Settings, error) {
+	s := &Settings{
+		CacheTimeout: 3600,
+	}
+
+	current, err := user.Current()
+	if err != nil {
+		return s, err
+	}
+
+	s.filePath = path.Join(current.HomeDir, SettingsDir, SettingsFilename)
+	return s, nil
+}
+
+func (s *Settings) Load() error {
+	fp, err := os.Open(s.filePath)
+	if err != nil {
+		if errors.Is(os.ErrExist, err) {
+			return err
+		} else {
+			return nil
+		}
+	}
+	defer fp.Close()
+
+	decoder := json.NewDecoder(fp)
+	return decoder.Decode(s)
+}
+
+func (s *Settings) Save() error {
+	if err := os.MkdirAll(path.Base(s.filePath), 0700); err != nil {
+		return err
+	}
+
+	fp, err := os.Create(s.filePath)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	encoder := json.NewEncoder(fp)
+	return encoder.Encode(s)
+}

--- a/lib/settings.go
+++ b/lib/settings.go
@@ -44,7 +44,7 @@ func (s *Settings) Load() error {
 }
 
 func (s *Settings) Save() error {
-	if err := os.MkdirAll(path.Base(s.filePath), 0700); err != nil {
+	if err := os.MkdirAll(path.Dir(s.filePath), 0700); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR does the following:

* implements a generic Item Cache that filters can use to cache items and avoid lookups
* Refactors the workspace retrieval into a struct with an embedded interface, which makes it easy to cache the workspaces.